### PR TITLE
Implement profile update action

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -13,6 +13,8 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useAuth } from '@/features/auth/hooks';
+import { updateProfile } from '@/features/profile';
+import { toast } from 'sonner';
 import {
   Camera,
   Download,
@@ -39,13 +41,22 @@ export default function ProfilePage() {
 
   const handleSave = async () => {
     setIsLoading(true);
-    // TODO: Implement save logic with your API
     try {
-      // await updateProfile(formData);
-      console.log('Saving profile:', formData);
-      setIsEditing(false);
+      const result = await updateProfile({
+        name: formData.name,
+        bio: formData.bio,
+        cv: formData.cv,
+      });
+
+      if (result.success) {
+        toast.success('Profil mis à jour !');
+        setIsEditing(false);
+      } else {
+        toast.error(result.error || 'Erreur lors de la mise à jour');
+      }
     } catch (error) {
       console.error('Failed to save profile:', error);
+      toast.error('Une erreur inattendue est survenue');
     } finally {
       setIsLoading(false);
     }

--- a/src/features/profile/actions.ts
+++ b/src/features/profile/actions.ts
@@ -1,0 +1,35 @@
+'use server';
+
+import { getRequiredUser } from '@/lib/auth-server';
+import { prisma } from '@/lib/prisma';
+import { UserProfileFormSchema, UserSchema, type UserProfileForm } from '@/schemas/user';
+
+export type UpdateProfileResponse = {
+  success: boolean;
+  data?: typeof UserSchema._type;
+  error?: string;
+};
+
+export async function updateProfile(data: UserProfileForm): Promise<UpdateProfileResponse> {
+  try {
+    const user = await getRequiredUser();
+    const validatedData = UserProfileFormSchema.parse(data);
+
+    const updatedUser = await prisma.user.update({
+      where: { id: user.id },
+      data: {
+        name: validatedData.name,
+        bio: validatedData.bio ?? null,
+        cv: validatedData.cv ?? null,
+      },
+    });
+
+    return { success: true, data: UserSchema.parse(updatedUser) };
+  } catch (error) {
+    console.error('Error updating profile:', error);
+    if (error instanceof Error) {
+      return { success: false, error: error.message };
+    }
+    return { success: false, error: "Une erreur inattendue s'est produite" };
+  }
+}

--- a/src/features/profile/index.ts
+++ b/src/features/profile/index.ts
@@ -1,0 +1,1 @@
+export * from './actions';


### PR DESCRIPTION
## Summary
- add server action to update current user profile
- wire profile page to use `updateProfile` and toast results

## Testing
- `pnpm lint`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_6864ea5d0c4c8329975671fa308a29df