### PR TITLE
feat(artists): make artist first name optional

### DIFF
--- a/app/api/artists/[artistId]/route.ts
+++ b/app/api/artists/[artistId]/route.ts
@@ -68,7 +68,7 @@ export async function PUT(
     const artist = await prisma.artist.update({
       where: { id: artistId },
       data: {
-        ...(data.firstName && { firstName: data.firstName }),
+        ...(data.firstName !== undefined && { firstName: data.firstName }),
         ...(data.lastName && { lastName: data.lastName }),
         ...(data.birthDate !== undefined && {
           birthDate: data.birthDate ? new Date(data.birthDate) : null,

--- a/app/api/artists/route.ts
+++ b/app/api/artists/route.ts
@@ -132,7 +132,7 @@ export async function POST(request: NextRequest) {
     // Create artist
     const artist = await prisma.artist.create({
       data: {
-        firstName: data.firstName,
+        firstName: data.firstName ?? null,
         lastName: data.lastName,
         birthDate: data.birthDate ? new Date(data.birthDate) : null,
         deathDate: data.deathDate ? new Date(data.deathDate) : null,

--- a/app/artworks/[artworkId]/page.tsx
+++ b/app/artworks/[artworkId]/page.tsx
@@ -1,5 +1,6 @@
 import { getArtworkById, incrementArtworkViewCount } from '@/features/artworks/actions';
 import { ArtworkDetail } from '@/features/artworks/components';
+import { formatArtistName } from '@/lib/artist-name';
 import { Metadata } from 'next';
 import { headers } from 'next/headers';
 import { notFound } from 'next/navigation';
@@ -19,7 +20,7 @@ export async function generateMetadata({ params }: ArtworkPageProps): Promise<Me
   }
   return {
     title: `ArtNote - ${artwork.title}`,
-    description: `Découvrez la notice "${artwork.title}" de ${artwork.artists.map(artist => `${artist.artist.firstName} ${artist.artist.lastName}`).join(', ')}.`,
+    description: `Découvrez la notice "${artwork.title}" de ${artwork.artists.map(artist => formatArtistName(artist.artist)).join(', ')}.`,
     openGraph: {
       images: artwork.images.filter(image => image.isMain).length
         ? artwork.images

--- a/app/dashboard/artists/[artistId]/page.tsx
+++ b/app/dashboard/artists/[artistId]/page.tsx
@@ -3,6 +3,7 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { ArtistForm } from '@/features/artists';
 import { useArtist } from '@/features/artists/hooks/use-artists';
+import { formatArtistName } from '@/lib/artist-name';
 import { useParams } from 'next/navigation';
 
 export default function EditArtistPage() {
@@ -28,7 +29,7 @@ export default function EditArtistPage() {
       <div>
         <h1 className="text-3xl font-bold">Modifier l'artiste</h1>
         <p className="text-muted-foreground mt-2">
-          Modifiez les informations de "{artist.firstName} {artist.lastName}"
+          Modifiez les informations de "{formatArtistName(artist)}"
         </p>
       </div>
 

--- a/prisma/migrations/20260516120000_make_artist_first_name_optional/migration.sql
+++ b/prisma/migrations/20260516120000_make_artist_first_name_optional/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "artist" ALTER COLUMN "firstName" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -99,7 +99,7 @@ model Verification {
 
 model Artist {
   id          String    @id @default(cuid())
-  firstName   String
+  firstName   String?
   lastName    String
   birthDate   DateTime?
   deathDate   DateTime?

--- a/src/features/artists/actions/artist-actions.ts
+++ b/src/features/artists/actions/artist-actions.ts
@@ -22,7 +22,7 @@ export async function createArtist(formData: FormData) {
     // Create artist
     await prisma.artist.create({
       data: {
-        firstName: data.firstName,
+        firstName: data.firstName ?? null,
         lastName: data.lastName,
         birthDate: data.birthDate ? new Date(data.birthDate) : null,
         deathDate: data.deathDate ? new Date(data.deathDate) : null,
@@ -56,7 +56,7 @@ export async function updateArtist(artistId: string, formData: FormData) {
     await prisma.artist.update({
       where: { id: artistId },
       data: {
-        firstName: data.firstName,
+        firstName: data.firstName ?? null,
         lastName: data.lastName,
         birthDate: data.birthDate ? new Date(data.birthDate) : null,
         deathDate: data.deathDate ? new Date(data.deathDate) : null,

--- a/src/features/artists/components/artist-form.tsx
+++ b/src/features/artists/components/artist-form.tsx
@@ -35,8 +35,8 @@ export function ArtistForm({ artist, mode }: ArtistFormProps) {
     <form action={handleSubmit} className="space-y-6">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div className="space-y-2">
-          <Label htmlFor="firstName">Prénom *</Label>
-          <Input id="firstName" name="firstName" defaultValue={artist?.firstName} required />
+          <Label htmlFor="firstName">Prénom</Label>
+          <Input id="firstName" name="firstName" defaultValue={artist?.firstName ?? ''} />
         </div>
 
         <div className="space-y-2">

--- a/src/features/artists/components/artists-table-columns.tsx
+++ b/src/features/artists/components/artists-table-columns.tsx
@@ -12,6 +12,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Artist } from '@/schemas/artist';
+import { formatArtistName } from '@/lib/artist-name';
 import { ColumnDef } from '@tanstack/react-table';
 import { ArrowUpDown, Edit, MoreHorizontal, Trash2 } from 'lucide-react';
 import Link from 'next/link';
@@ -64,7 +65,7 @@ export const columns: ColumnDef<ArtistWithRelations>[] = [
     ),
     cell: ({ row }) => {
       const artist = row.original;
-      const fullName = `${artist.firstName} ${artist.lastName}`;
+      const fullName = formatArtistName(artist);
       return (
         <Link href={`/dashboard/artists/${artist.id}`} className="font-medium hover:underline">
           {fullName}
@@ -147,7 +148,7 @@ export const columns: ColumnDef<ArtistWithRelations>[] = [
     enableHiding: false,
     cell: ({ row }) => {
       const artist = row.original;
-      const fullName = `${artist.firstName} ${artist.lastName}`;
+      const fullName = formatArtistName(artist);
 
       const handleDelete = async () => {
         if (confirm(`Êtes-vous sûr de vouloir supprimer "${fullName}" ?`)) {

--- a/src/features/artworks/actions/get-artworks.ts
+++ b/src/features/artworks/actions/get-artworks.ts
@@ -1,4 +1,5 @@
 import { Prisma } from '@/generated/prisma/client';
+import { formatArtistName } from '@/lib/artist-name';
 import { prisma } from '@/lib/prisma';
 import { ArtworkSchema, ArtworkStatusSchema, UserSchema } from '@/schemas';
 
@@ -218,12 +219,8 @@ export async function getFilteredArtworks(filters: ArtworkFilters = {}) {
     // For artist sorting, we need to sort manually since Prisma doesn't handle it well
     if (sort === 'artist') {
       artworks.sort((a: (typeof artworks)[number], b: (typeof artworks)[number]) => {
-        const artistA = a.artists[0]?.artist
-          ? `${a.artists[0].artist.firstName} ${a.artists[0].artist.lastName}`
-          : '';
-        const artistB = b.artists[0]?.artist
-          ? `${b.artists[0].artist.firstName} ${b.artists[0].artist.lastName}`
-          : '';
+        const artistA = a.artists[0]?.artist ? formatArtistName(a.artists[0].artist) : '';
+        const artistB = b.artists[0]?.artist ? formatArtistName(b.artists[0].artist) : '';
 
         const comparison = artistA.localeCompare(artistB, 'fr', {
           sensitivity: 'base',

--- a/src/features/artworks/components/admin/artist-selector.tsx
+++ b/src/features/artworks/components/admin/artist-selector.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { useDebounce } from '@/hooks/use-debounce';
+import { formatArtistName } from '@/lib/artist-name';
 import { cn } from '@/lib/utils';
 import { Artist } from '@/schemas/artist';
 import { Check, ChevronsUpDown, X } from 'lucide-react';
@@ -53,10 +54,6 @@ export function ArtistSelector({
     onSelectionChange(selectedArtists.filter(a => a.id !== artistId));
   };
 
-  const formatArtistName = (artist: Artist) => {
-    return `${artist.firstName} ${artist.lastName}`;
-  };
-
   return (
     <div className={cn('space-y-2', className)}>
       <Popover open={open} onOpenChange={setOpen}>
@@ -89,7 +86,7 @@ export function ArtistSelector({
                   return (
                     <CommandItem
                       key={artist.id}
-                      value={`${artist.firstName} ${artist.lastName}`}
+                      value={formatArtistName(artist)}
                       onSelect={() => handleSelect(artist)}
                     >
                       <Check

--- a/src/features/artworks/components/artwork-card.tsx
+++ b/src/features/artworks/components/artwork-card.tsx
@@ -1,6 +1,7 @@
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
+import { formatArtistName } from '@/lib/artist-name';
 import { Artwork, User } from '@/schemas';
 import { formatDistanceToNow } from 'date-fns';
 import { fr } from 'date-fns/locale';
@@ -73,7 +74,7 @@ export function ArtworkCard({ artwork }: ArtworkCardProps) {
               {/* Artists */}
               {artists && artists.length > 0 && (
                 <p className="text-sm text-muted-foreground line-clamp-1 sm:line-clamp-none">
-                  Par {artists.map(a => a.artist.firstName + ' ' + a.artist.lastName).join(', ')}
+                  Par {artists.map(a => formatArtistName(a.artist)).join(', ')}
                 </p>
               )}
             </div>

--- a/src/features/artworks/components/artwork-detail.tsx
+++ b/src/features/artworks/components/artwork-detail.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { RichTextViewer } from '@/components/ui/rich-text-editor';
 import { Separator } from '@/components/ui/separator';
 import { useNoticeAnalytics } from '@/hooks/use-notice-analytics';
+import { formatArtistName } from '@/lib/artist-name';
 import { Artwork, User } from '@/schemas';
 import { Calendar, MapPin, Palette, Ruler } from 'lucide-react';
 import { useRef } from 'react';
@@ -48,7 +49,7 @@ export function ArtworkDetail({ artwork }: ArtworkDetailProps) {
               {artists.map((artworkArtist, index) => (
                 <div key={artworkArtist.artist.id} className="flex items-center">
                   <div className="text-lg md:text-xl text-muted-foreground">
-                    {artworkArtist.artist.firstName} {artworkArtist.artist.lastName}
+                    {formatArtistName(artworkArtist.artist)}
                     {artworkArtist.role && (
                       <span className="text-sm font-normal ml-1">({artworkArtist.role})</span>
                     )}

--- a/src/lib/artist-name.ts
+++ b/src/lib/artist-name.ts
@@ -1,0 +1,3 @@
+export function formatArtistName(artist: { firstName?: string | null; lastName: string }) {
+  return [artist.firstName, artist.lastName].filter(Boolean).join(' ');
+}

--- a/src/schemas/artist.ts
+++ b/src/schemas/artist.ts
@@ -7,7 +7,7 @@ import { PaginationSchema, SearchSchema } from './common';
 
 export const ArtistSchema = z.object({
   id: z.string(),
-  firstName: z.string(),
+  firstName: z.string().nullable(),
   lastName: z.string(),
   birthDate: z.date().nullable(),
   deathDate: z.date().nullable(),
@@ -29,6 +29,10 @@ export const CreateArtistSchema = ArtistSchema.omit({
   createdById: true,
   updatedById: true,
 }).extend({
+  firstName: z.preprocess(
+    value => (typeof value === 'string' && value.trim() === '' ? null : value),
+    z.string().max(100, 'Le prénom est trop long').nullable().optional(),
+  ),
   birthDate: z.string().optional().nullable(),
   deathDate: z.string().optional().nullable(),
 });
@@ -53,7 +57,10 @@ export const ArtistFiltersSchema = z
 // =============================================================================
 
 export const ArtistFormSchema = z.object({
-  firstName: z.string().min(1, 'Le prénom est requis').max(100, 'Le prénom est trop long'),
+  firstName: z.preprocess(
+    value => (typeof value === 'string' && value.trim() === '' ? null : value),
+    z.string().max(100, 'Le prénom est trop long').nullable().optional(),
+  ),
   lastName: z.string().min(1, 'Le nom est requis').max(100, 'Le nom est trop long'),
   birthDate: z.string().optional(),
   deathDate: z.string().optional(),


### PR DESCRIPTION
## Summary

- Make `Artist.firstName` nullable in Prisma (migration + schema) and relax Zod validation so first name is optional; blank input is normalized to `null`.
- Persist and update missing first names as `null` in server actions and artist API routes (including clearing first name on update).
- Add shared `formatArtistName()` and use it across the app so artists display as last name only when first name is absent (dashboard, artwork views, selectors, metadata).
- Remove required first-name field from the artist form UI.

## Testing

- [ ] Run the new migration (`make_artist_first_name_optional`) against a local/dev database.
- [ ] Create an artist with **last name only** (leave first name empty) and confirm it saves and appears correctly in the artists table.
- [ ] Create an artist with both first and last name and confirm display is unchanged (`First Last`).
- [ ] Edit an existing artist: clear the first name, save, and confirm the value is stored as `null` and shown as last name only.
- [ ] Verify artist names on artwork list cards, artwork detail page, and public artwork metadata/description.
- [ ] Verify artist selector search/labels and artwork sorting by artist still behave correctly.
- Not run: automated test suite.